### PR TITLE
chore: migrate publish workflows to reusable

### DIFF
--- a/.github/workflows/publish-ontology-to-production.yml
+++ b/.github/workflows/publish-ontology-to-production.yml
@@ -1,5 +1,8 @@
 name: Publish ontology to data.norge.no/vocabulary
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:
@@ -8,49 +11,22 @@ on:
       - ontology/**
   workflow_dispatch:
 
-permissions:
-  contents: read
-
 jobs:
-  test_uploading_of_file:
+  upload-files-to-production:
     name: Upload vocabulary to static-rdf-server
-    runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          ref: v1
-          submodules: true
-          fetch-depth: 0
-
-      - name: Update submodules to latest main
-        run: |
-          git submodule foreach --recursive git fetch origin
-          git submodule foreach --recursive git checkout origin/main
-
-      - name: Build html en
-        id: adocbuild_html_en
-        uses: tonynv/asciidoctor-action@master
-        with:
-          program: "asciidoctor -a data-uri -D ontology -o index-en.html -a lang=en ontology/main-en.adoc"
-
-      - name: Build html nb
-        id: adocbuild_html_nb
-        uses: tonynv/asciidoctor-action@master
-        with:
-          program: "asciidoctor -a data-uri -D ontology -o index-nb.html -a lang=nb ontology/main-nb.adoc"
-
-      - name: Upload rdf to static-rdf-server
-        uses: Informasjonsforvaltning/upload-files-to-static-rdf-server-action@v3.2.0
-        id: upload-rdf
-        with:
-          host: "https://data.norge.no"
-          api-key: ${{ secrets.STATIC_RDF_SERVER_API_KEY }}
-          ontology-type: "vocabulary"
-          ontology: "provno"
-          files: |
-            ontology/provno.ttl text/turtle en
-            ontology/index-nb.html text/html nb
-            ontology/index-en.html text/html en
+    if: github.event_name != 'workflow_dispatch' || github.ref == 'refs/heads/v1'
+    uses: Informasjonsforvaltning/workflows/.github/workflows/specification-upload-files.yaml@main
+    with:
+      ref: v1
+      program_html: |
+        asciidoctor -a data-uri -D ontology -o index-en.html -a lang=en ontology/main-en.adoc
+        asciidoctor -a data-uri -D ontology -o index-nb.html -a lang=nb ontology/main-nb.adoc
+      host: https://data.norge.no
+      ontology: provno
+      ontology-type: vocabulary
+      files: |
+        ontology/provno.ttl text/turtle en
+        ontology/index-nb.html text/html nb
+        ontology/index-en.html text/html en
+    secrets:
+      STATIC_RDF_SERVER_API_KEY: ${{ secrets.STATIC_RDF_SERVER_API_KEY }}

--- a/.github/workflows/publish-ontology-to-staging.yml
+++ b/.github/workflows/publish-ontology-to-staging.yml
@@ -2,7 +2,6 @@ name: Publish ontology to staging.fellesdatakatalog.digdir.no/vocabulary
 
 permissions:
   contents: read
-  security-events: write
 
 on:
   push:
@@ -13,44 +12,20 @@ on:
   workflow_dispatch:
 
 jobs:
-  test_uploading_of_file:
+  upload-files-to-staging:
     name: Upload vocabulary to static-rdf-server
-    runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          submodules: true
-          fetch-depth: 0
-
-      - name: Update submodules to latest main
-        run: |
-          git submodule foreach --recursive git fetch origin
-          git submodule foreach --recursive git checkout origin/main
-
-      - name: Build html en
-        id: adocbuild_html_en
-        uses: tonynv/asciidoctor-action@master
-        with:
-          program: "asciidoctor -a data-uri -D ontology -o index-en.html -a lang=en ontology/main-en.adoc"
-
-      - name: Build html nb
-        id: adocbuild_html_nb
-        uses: tonynv/asciidoctor-action@master
-        with:
-          program: "asciidoctor -a data-uri -D ontology -o index-nb.html -a lang=nb ontology/main-nb.adoc"
-
-      - name: Upload rdf to static-rdf-server
-        uses: Informasjonsforvaltning/upload-files-to-static-rdf-server-action@v3.2.0
-        id: upload-rdf
-        with:
-          host: "https://staging.fellesdatakatalog.digdir.no"
-          api-key: ${{ secrets.STATIC_RDF_SERVER_API_KEY_STAGING }}
-          ontology-type: "vocabulary"
-          ontology: "provno"
-          files: |
-            ontology/provno.ttl text/turtle en
-            ontology/index-nb.html text/html nb
-            ontology/index-en.html text/html en
+    if: github.event_name != 'workflow_dispatch' || github.ref == 'refs/heads/develop'
+    uses: Informasjonsforvaltning/workflows/.github/workflows/specification-upload-files.yaml@main
+    with:
+      program_html: |
+        asciidoctor -a data-uri -D ontology -o index-en.html -a lang=en ontology/main-en.adoc
+        asciidoctor -a data-uri -D ontology -o index-nb.html -a lang=nb ontology/main-nb.adoc
+      host: https://staging.fellesdatakatalog.digdir.no
+      ontology: provno
+      ontology-type: vocabulary
+      files: |
+        ontology/provno.ttl text/turtle en
+        ontology/index-nb.html text/html nb
+        ontology/index-en.html text/html en
+    secrets:
+      STATIC_RDF_SERVER_API_KEY: ${{ secrets.STATIC_RDF_SERVER_API_KEY_STAGING }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 build
+.idea


### PR DESCRIPTION
# Summary

Migrate the ontology publish workflows to the centralized reusable `Informasjonsforvaltning/workflows/.github/workflows/specification-upload-files.yaml@main`.

- Replace local asciidoctor build + upload steps in staging and production workflows with a call to the reusable workflow
- Remove unpinned third-party actions (asciidoctor-action@master, checkout@v4, upload-action@v3.2.0); the reusable workflow pins all of them to SHAs/digests
- Reduce staging permissions to `contents: read` and drop the dead draft-PR guard
- Add `.idea` to `.gitignore`
- Closes #19